### PR TITLE
Export transformBefore instead of transform

### DIFF
--- a/lib/esformatter-var-each.js
+++ b/lib/esformatter-var-each.js
@@ -307,6 +307,6 @@ exports._transformNode = function (node) {
 
 // Export our transformation
 // https://github.com/millermedeiros/esformatter/tree/v0.4.3#transformbeforeast
-exports.transform = function (ast) {
+exports.transformBefore = function (ast) {
   rocambole.moonwalk(ast, exports._transformNode);
 };

--- a/test/esformatter-var-each-test.js
+++ b/test/esformatter-var-each-test.js
@@ -100,6 +100,15 @@ describe('esformatter-var-each', function () {
       expect(this.output).to.equal(expectedOutput);
     });
   });
+
+  describe('formatting a JS file with object value', function () {
+    testUtils.format(__dirname + '/test-files/basic-object.js');
+
+    it('results in properly indented output', function () {
+      var expectedOutput = fs.readFileSync(__dirname + '/expected-files/basic-object.js', 'utf8');
+      expect(this.output).to.equal(expectedOutput);
+    });
+  });
 });
 
 // Intermediate tests

--- a/test/expected-files/basic-object.js
+++ b/test/expected-files/basic-object.js
@@ -1,0 +1,4 @@
+var a = 'hello';
+var b = {
+  x: 'world'
+};

--- a/test/test-files/basic-object.js
+++ b/test/test-files/basic-object.js
@@ -1,0 +1,3 @@
+var a = 'hello', b = {
+	x: 'world'
+};


### PR DESCRIPTION
When transform is exported it is aliased to transformAfter. I think using transformBefore is intended (based on comment), makes more sense and will resolve an indentation issue I'm running into now
